### PR TITLE
Create homebridge-delayed-occupancy v2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,28 @@
-# "Occupancy Delay" Plugin
+# Delayed Occupancy Sensor Plugin for Homebridge
 
 
 ## How to install
 
  ```sudo npm install -g homebridge-occupancy-delay```
 
-## Example config.json:
+## Example `config.json`
 
- ```
+ ```json
     "accessories": [
         {
-          "accessory": "OccupancyDelay",
-          "name": "OccupancyDelay",
+          "accessory": "delayed-occupancy-sensor",
+          "name": "Delayed Occupancy Sensor",
           "delay": 5,
-          "switchCount": 1
+          "switches": [
+            "First activation switch",
+            "Second activation switch"
+          ]
         }
     ]
 ```
 
-Note, "delay" is in seconds.
+Note, "delay" is in seconds. The `switches` list is optional. The plugin will
+always create at least one activation switch.
 
 ## What problem will this solve?
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "@djelibeybi/homebridge-delayed-occupancy",
+  "version": "2.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@djelibeybi/homebridge-delayed-occupancy",
+      "version": "2.0.0",
+      "license": "GPL-3.0",
+      "engines": {
+        "homebridge": ">=0.2.5"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "homebridge-occupancy-delay",
-  "version": "1.0.1",
+  "name": "@djelibeybi/homebridge-delayed-occupancy",
+  "version": "2.0.0",
   "description": "Occupancy sensor linked to one or more switches with a built-in not-unoccupied delay for Homebridge: https://github.com/nfarina/homebridge",
   "main": "index.js",
   "license": "GPL-3.0",
   "keywords": [
+    "homebridge",
     "homebridge-plugin",
     "occupancy",
     "motion sensor",
@@ -13,7 +14,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/archanglmr/homebridge-occupancy-delay.git"
+    "url": "https://github.com/Djelibeybi/homebridge-delayed-occupancy.git"
   },
   "engines": {
     "homebridge": ">=0.2.5"


### PR DESCRIPTION
This is based on https://github.com/archanglmr/homebridge-occupancy-delay but has been renamed to `homebridge-delayed-occupancy` and had its version bumped to 2.0 as the new configuration is not backwards-compatible. See the `README.md` for updated config syntax.