### PR TITLE
feat: add unique serial numbers for each sensor

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -22,7 +22,7 @@
         "default": 5
       },
       "switches": {
-        "title": "Activation swtiches",
+        "title": "Activation switches",
         "description": "Add one or more activation switches for this occupancy sensor.",
         "type": "array",
         "required": false,


### PR DESCRIPTION
This should improve the ability to backup HomeKit data as the sensors
won't all have the same serial number.

Also fixed a typo in the config UI.

Signed-off-by: Avi Miller <me@dje.li>